### PR TITLE
Fixed GamePadInputBuffer stack pop

### DIFF
--- a/game/src/screen/GamePadInputBuffer.js
+++ b/game/src/screen/GamePadInputBuffer.js
@@ -253,7 +253,7 @@ GamePadInputBuffer.prototype.nextMovement = function()
     {   var m = this.movebuffer[0];
         this.nummoves--;
         if (this.nummoves>0)
-        {   for (var i=0; i<this.nummoves-1; i++)
+        {   for (var i=0; i<this.nummoves; i++)
             {   this.movebuffer[i] = this.movebuffer[i+1];
             }
         }


### PR DESCRIPTION
Hi! So I was trying the game out and I noticed that the movement doesn't seem quite right. Specifically, if you hold one direction and then very quickly tap a perpendicular direction, sometimes you end up going _two_ spaces in the second direction.

The bug is just an off-by-one error in `nextMovement()`. When `this.nummoves == 2` at the start of the function, it is decremented at line 254 and then the for loop check for  `i < nummoves-1` immediately is False, so the buffer is not shifted and the next time this function is called it will return the same move as the last time! I removed the `-1` in the check and now the game movement feels like it used to.
